### PR TITLE
Removed the default navigation properties to load in navigation from portal settings

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -8,13 +8,16 @@ import { useStoreon } from "../..";
 
 import { NavigationProps } from "./types";
 import { navigation as configNav } from "./config";
+import merge from "deepmerge";
 
 export const Navigation: React.FC<NavigationProps> = ({ contractible = false, className, ...rest }) => {
   const { palette, zIndex, spacing } = useTheme();
   const { storefrontConfig } = useStoreon("storefrontConfig");
   const { ownerInfo } = useConfig();
-  const { navigation } = useConfig();
+  //let { navigation } = useConfig();
   const { t } = useTranslation();
+
+  const navigation = merge(configNav, storefrontConfig.navigation || {});
 
   const role = "anonymous";
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -13,11 +13,10 @@ export const Navigation: React.FC<NavigationProps> = ({ contractible = false, cl
   const { palette, zIndex, spacing } = useTheme();
   const { storefrontConfig } = useStoreon("storefrontConfig");
   const { ownerInfo } = useConfig();
-  let { navigation } = useConfig();
+  const { navigation } = useConfig();
   const { t } = useTranslation();
 
   const role = "anonymous";
-  navigation = { ...navigation, ...configNav };
 
   const [isMaxWidth, setIsMaxWidth] = useState(window.innerWidth <= 1024);
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -14,7 +14,6 @@ export const Navigation: React.FC<NavigationProps> = ({ contractible = false, cl
   const { palette, zIndex, spacing } = useTheme();
   const { storefrontConfig } = useStoreon("storefrontConfig");
   const { ownerInfo } = useConfig();
-  //let { navigation } = useConfig();
   const { t } = useTranslation();
 
   const navigation = merge(configNav, storefrontConfig.navigation || {});


### PR DESCRIPTION
In the current implementation of the storefront, default navigation options are combined with the navigation options of the portal. Just as with the main frontend, it should load in the navigation options from the storefront settings.