### PR TITLE
Set the title of the storefront to the name of the portal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,9 @@ const App: React.FC = () => {
     if (storefrontConfig && storefrontConfig.theme) {
       appTheme.current = createMuiTheme(merge(defaultTheme, storefrontConfig.theme));
     }
+    if (storefrontConfig && storefrontConfig.portalName) {
+      document.title = storefrontConfig.portalName;
+    }
   }, [storefrontConfig]);
 
   return (


### PR DESCRIPTION
Currently the storefront page has the title "Storefront". Changes have been made to change this to name of the portal as defined in the storefront's settings.